### PR TITLE
Newline take 2

### DIFF
--- a/src/egherkin.erl
+++ b/src/egherkin.erl
@@ -16,7 +16,7 @@
 
 -module(egherkin).
 
--export([lexer/1, lexer/2, from_lexer/1, parse/1, parse_file/1]).
+-export([lexer/1, from_lexer/1, parse/1, parse_file/1]).
 
 -define(is_gwt(V), ((V == given_keyword)
   orelse (V == when_keyword)
@@ -28,88 +28,75 @@
 
 -define(is_crlf(C), ((C == $\r) orelse (C == $\n))).
 
-%% @doc assumes that the file source data have
 lexer(Source) ->
-  lexer(Source, io_lib:nl() =:= "\n").
+  lexer(Source, {keepwhite, <<>>}, []).
 
-lexer(Source, WindowsNewLine) ->
-  lexer(Source, {keepwhite, <<>>}, [], WindowsNewLine).
-
-lexer(<<>>, _Text, Result, _NewLine) ->
+lexer(<<>>, _Text, Result) ->
   lists:reverse(Result);
 
-lexer(<<$#, S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipcomment, Result, NewLine);
-lexer(<<"Feature:", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [feature_keyword | Result], NewLine);
-lexer(<<"Background:", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [background_keyword | Result], NewLine);
-lexer(<<"Scenario Outline:", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [scenario_outline_keyword | Result], NewLine);
-lexer(<<"Scenario:", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [scenario_keyword | Result], NewLine);
-lexer(<<"Examples:", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [examples_keyword | Result], NewLine);
-lexer(<<"Given", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [given_keyword | Result], NewLine);
-lexer(<<"When", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [when_keyword | Result], NewLine);
-lexer(<<"Then", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [then_keyword | Result], NewLine);
-lexer(<<"And", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [and_keyword | Result], NewLine);
-lexer(<<"But", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [but_keyword | Result], NewLine);
-lexer(<<"\"\"\"", S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [docstring_keyword | Result], NewLine);
-lexer(<<$@, S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [at_sign | Result], NewLine);
+lexer(<<$#, S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipcomment, Result);
+lexer(<<"Feature:", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [feature_keyword | Result]);
+lexer(<<"Background:", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [background_keyword | Result]);
+lexer(<<"Scenario Outline:", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [scenario_outline_keyword | Result]);
+lexer(<<"Scenario:", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [scenario_keyword | Result]);
+lexer(<<"Examples:", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [examples_keyword | Result]);
+lexer(<<"Given", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [given_keyword | Result]);
+lexer(<<"When", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [when_keyword | Result]);
+lexer(<<"Then", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [then_keyword | Result]);
+lexer(<<"And", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [and_keyword | Result]);
+lexer(<<"But", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [but_keyword | Result]);
+lexer(<<"\"\"\"", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [docstring_keyword | Result]);
+lexer(<<$@, S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, skipwhite, [at_sign | Result]);
+lexer(<<"\r\n", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<C, S/binary>>, {keepwhite, _White}, Result) when ?is_crlf(C) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<C, S/binary>>, {keepwhite, White}, Result) when ?is_white(C) ->
+  lexer(S, {keepwhite, <<White/binary, C>>}, Result);
+lexer(<<C, S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, {keeptext, <<C>>, <<>>}, Result);
 
-lexer(<<"\r\n", S/binary>>, {keepwhite, _White}, Result, true=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<"\n", S/binary>>, {keepwhite, _White}, Result, false=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<C, S/binary>>, {keepwhite, _White}, Result, NewLine) when ?is_crlf(C) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<C, S/binary>>, {keepwhite, White}, Result, NewLine) when ?is_white(C) ->
-  lexer(S, {keepwhite, <<White/binary, C>>}, Result, NewLine);
-lexer(<<C, S/binary>>, {keepwhite, _White}, Result, NewLine) ->
-  lexer(S, {keeptext, <<C>>, <<>>}, Result, NewLine);
+lexer(<<"\r\n", S/binary>>, skipcomment, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<C, S/binary>>, skipcomment, Result) when ?is_crlf(C) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<_, S/binary>>, skipcomment, Result) ->
+  lexer(S, skipcomment, Result);
 
-lexer(<<"\r\n", S/binary>>, skipcomment, Result, true=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<"\n", S/binary>>, skipcomment, Result, false=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<C, S/binary>>, skipcomment, Result, NewLine) when ?is_crlf(C) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<_, S/binary>>, skipcomment, Result, NewLine) ->
-  lexer(S, skipcomment, Result, NewLine);
+lexer(<<"\r\n", S/binary>>, skipwhite, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<C, S/binary>>, skipwhite, Result) when ?is_crlf(C) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<C, S/binary>>, skipwhite, Result) when ?is_white(C) ->
+  lexer(S, skipwhite, Result);
+lexer(<<C, S/binary>>, skipwhite, Result) ->
+  lexer(S, {keeptext, <<C>>, <<>>}, Result);
 
-lexer(<<"\r\n", S/binary>>, skipwhite, Result, true=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<"\n", S/binary>>, skipwhite, Result, false=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<C, S/binary>>, skipwhite, Result, NewLine) when ?is_crlf(C) ->
-  lexer(S, {keepwhite, <<>>}, [crlf | Result], NewLine);
-lexer(<<C, S/binary>>, skipwhite, Result, NewLine) when ?is_white(C) ->
-  lexer(S, skipwhite, Result, NewLine);
-lexer(<<C, S/binary>>, skipwhite, Result, NewLine) ->
-  lexer(S, {keeptext, <<C>>, <<>>}, Result, NewLine);
-
-lexer(<<"\r\n", S/binary>>, {keeptext, Text, _White}, Result, true=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf, Text | Result], NewLine);
-lexer(<<"\n", S/binary>>, {keeptext, Text, _White}, Result, false=NewLine) ->
-  lexer(S, {keepwhite, <<>>}, [crlf, Text | Result], NewLine);
-lexer(<<C, S/binary>>, {keeptext, Text, _White}, Result, NewLine) when ?is_crlf(C) ->
-  lexer(S, <<>>, [crlf, Text | Result], NewLine);
-lexer(<<$@, S/binary>>, {keeptext, <<>>, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [at_sign | Result], NewLine);
-lexer(<<$@, S/binary>>, {keeptext, Text, _White}, Result, NewLine) ->
-  lexer(S, skipwhite, [at_sign, Text | Result], NewLine);
-lexer(<<C, S/binary>>, {keeptext, Text, White}, Result, NewLine) when ((C == $\s) orelse (C == $\t)) ->
-  lexer(S, {keeptext, Text, <<White/binary, C>>}, Result, NewLine);
-lexer(<<C, S/binary>>, {keeptext, Text, White}, Result, NewLine) ->
-  lexer(S, {keeptext, <<Text/binary, White/binary, C>>, <<>>}, Result, NewLine).
+lexer(<<"\r\n", S/binary>>, {keeptext, Text, _White}, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf, Text | Result]);
+lexer(<<C, S/binary>>, {keeptext, Text, _White}, Result) when ?is_crlf(C) ->
+  lexer(S, <<>>, [crlf, Text | Result]);
+lexer(<<$@, S/binary>>, {keeptext, <<>>, _White}, Result) ->
+  lexer(S, skipwhite, [at_sign | Result]);
+lexer(<<$@, S/binary>>, {keeptext, Text, _White}, Result) ->
+  lexer(S, skipwhite, [at_sign, Text | Result]);
+lexer(<<C, S/binary>>, {keeptext, Text, White}, Result) when ((C == $\s) orelse (C == $\t)) ->
+  lexer(S, {keeptext, Text, <<White/binary, C>>}, Result);
+lexer(<<C, S/binary>>, {keeptext, Text, White}, Result) ->
+  lexer(S, {keeptext, <<Text/binary, White/binary, C>>, <<>>}, Result).
 
 from_lexer(L) ->
   Parsers = [

--- a/src/egherkin.erl
+++ b/src/egherkin.erl
@@ -62,6 +62,8 @@ lexer(<<$@, S/binary>>, {keepwhite, _White}, Result) ->
   lexer(S, skipwhite, [at_sign | Result]);
 lexer(<<"\r\n", S/binary>>, {keepwhite, _White}, Result) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<"\n", S/binary>>, {keepwhite, _White}, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
 lexer(<<C, S/binary>>, {keepwhite, _White}, Result) when ?is_crlf(C) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
 lexer(<<C, S/binary>>, {keepwhite, White}, Result) when ?is_white(C) ->
@@ -71,12 +73,16 @@ lexer(<<C, S/binary>>, {keepwhite, _White}, Result) ->
 
 lexer(<<"\r\n", S/binary>>, skipcomment, Result) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<"\n", S/binary>>, skipcomment, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
 lexer(<<C, S/binary>>, skipcomment, Result) when ?is_crlf(C) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
 lexer(<<_, S/binary>>, skipcomment, Result) ->
   lexer(S, skipcomment, Result);
 
 lexer(<<"\r\n", S/binary>>, skipwhite, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf | Result]);
+lexer(<<"\n", S/binary>>, skipwhite, Result) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
 lexer(<<C, S/binary>>, skipwhite, Result) when ?is_crlf(C) ->
   lexer(S, {keepwhite, <<>>}, [crlf | Result]);
@@ -86,6 +92,8 @@ lexer(<<C, S/binary>>, skipwhite, Result) ->
   lexer(S, {keeptext, <<C>>, <<>>}, Result);
 
 lexer(<<"\r\n", S/binary>>, {keeptext, Text, _White}, Result) ->
+  lexer(S, {keepwhite, <<>>}, [crlf, Text | Result]);
+lexer(<<"\n", S/binary>>, {keeptext, Text, _White}, Result) ->
   lexer(S, {keepwhite, <<>>}, [crlf, Text | Result]);
 lexer(<<C, S/binary>>, {keeptext, Text, _White}, Result) when ?is_crlf(C) ->
   lexer(S, <<>>, [crlf, Text | Result]);

--- a/test/egherkin_SUITE.erl
+++ b/test/egherkin_SUITE.erl
@@ -35,7 +35,6 @@ end_per_testcase(_TestCase, Config) ->
 
 all() -> [
 	lexer_simple_scenario,
-	lexer_simple_scenario_linux,
 	lexer_background,
 	lexer_datatable_step,
 	lexer_docstring_step,
@@ -71,58 +70,52 @@ all() -> [
 
 lexer_simple_scenario(_) ->
 	Scenario = simple_scenario,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
-	ok.
-
-lexer_simple_scenario_linux(_) ->
-	InputScenario = simple_scenario_linux,
-	Scenario = simple_scenario,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(InputScenario), false)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_background(_) ->
 	Scenario = background,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_datatable_step(_) ->
 	Scenario = datatable_step,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_docstring_step(_) ->
 	Scenario = docstring_step,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_scenario_outline(_) ->
 	Scenario = scenario_outline,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_feature_tags(_) ->
 	Scenario = feature_tags,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_scenario_tags(_) ->
 	Scenario = scenario_tags,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_multiple_scenarios(_) ->
 	Scenario = multiple_scenarios,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_lots_of_crlfs(_) ->
 	Scenario = lots_of_crlfs,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 lexer_lots_of_comments(_) ->
 	Scenario = lots_of_comments,
-	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario), true)),
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
 	ok.
 
 %%endregion

--- a/test/egherkin_SUITE.erl
+++ b/test/egherkin_SUITE.erl
@@ -35,6 +35,7 @@ end_per_testcase(_TestCase, Config) ->
 
 all() -> [
 	lexer_simple_scenario,
+	lexer_simple_scenario_linux,
 	lexer_background,
 	lexer_datatable_step,
 	lexer_docstring_step,
@@ -71,6 +72,12 @@ all() -> [
 lexer_simple_scenario(_) ->
 	Scenario = simple_scenario,
 	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(Scenario))),
+	ok.
+
+lexer_simple_scenario_linux(_) ->
+	InputScenario = simple_scenario_linux,
+	Scenario = simple_scenario,
+	?assertEqual(test_data:lexer_output(Scenario), egherkin:lexer(test_data:source(InputScenario))),
 	ok.
 
 lexer_background(_) ->

--- a/test/test_data.erl
+++ b/test/test_data.erl
@@ -27,15 +27,6 @@ source(simple_scenario) ->
 		"When I press add\r\n"
 		"Then the result should be 120 on the screen\r\n"
 	>>;
-source(simple_scenario_linux) ->
-	<<
-		"Feature: Addition\n"
-		"Scenario: Add two numbers\n"
-		"Given I have entered 50 into the calculator\n"
-		"And I have entered 70 into the calculator\n"
-		"When I press add\n"
-		"Then the result should be 120 on the screen\n"
-	>>;
 source(background) ->
 	<<
 		"Feature: Addition\r\n"

--- a/test/test_data.erl
+++ b/test/test_data.erl
@@ -27,6 +27,15 @@ source(simple_scenario) ->
 		"When I press add\r\n"
 		"Then the result should be 120 on the screen\r\n"
 	>>;
+source(simple_scenario_linux) ->
+	<<
+		"Feature: Addition\n"
+		"Scenario: Add two numbers\n"
+		"Given I have entered 50 into the calculator\n"
+		"And I have entered 70 into the calculator\n"
+		"When I press add\n"
+		"Then the result should be 120 on the screen\n"
+	>>;
 source(background) ->
 	<<
 		"Feature: Addition\r\n"


### PR DESCRIPTION
My first attempt at handling new lines for Linux, osx and windows was buggy and too complicated.

It seems erlang are handling both \r\n and \n as new line independent of which os you are using.
In python also \r (old macs) is identified as newline.
I've decided to go with the erlang approach.